### PR TITLE
bugfix in compiling submodule diff-gaussian-rasterization_fastgs

### DIFF
--- a/submodules/diff-gaussian-rasterization_fastgs/cuda_rasterizer/rasterizer_impl.h
+++ b/submodules/diff-gaussian-rasterization_fastgs/cuda_rasterizer/rasterizer_impl.h
@@ -13,6 +13,7 @@
 
 #include <iostream>
 #include <vector>
+#include <cstdint>
 #include "rasterizer.h"
 #include <cuda_runtime_api.h>
 


### PR DESCRIPTION
The problem arises because the definition of uint32_t is missing in some versions of gcc; therefore, adding the header file cstdint will resolve the issue.

<img width="3018" height="1031" alt="image" src="https://github.com/user-attachments/assets/469e6ca7-a893-460a-a3d4-34802dec34e8" />

