### PR TITLE
fix: replace 7 bare excepts with except Exception across 4 files

### DIFF
--- a/gaussian_renderer/__init__.py
+++ b/gaussian_renderer/__init__.py
@@ -27,7 +27,7 @@ def render_fastgs(viewpoint_camera, pc : GaussianModel, pipe, bg_color : torch.T
     screenspace_points = torch.zeros((pc.get_xyz.shape[0], 4), dtype=pc.get_xyz.dtype, requires_grad=True, device="cuda") + 0
     try:
         screenspace_points.retain_grad()
-    except:
+    except Exception:
         pass
 
     # Set up rasterization configuration

--- a/metrics.py
+++ b/metrics.py
@@ -89,7 +89,7 @@ def evaluate(model_paths):
                 json.dump(full_dict[scene_dir], fp, indent=True)
             with open(scene_dir + "/per_view.json", 'w') as fp:
                 json.dump(per_view_dict[scene_dir], fp, indent=True)
-        except:
+        except Exception:
             print("Unable to compute metrics for model", scene_dir)
 
 if __name__ == "__main__":

--- a/scene/dataset_readers.py
+++ b/scene/dataset_readers.py
@@ -135,7 +135,7 @@ def readColmapSceneInfo(path, images, eval, llffhold=8):
         cameras_intrinsic_file = os.path.join(path, "sparse/0", "cameras.bin")
         cam_extrinsics = read_extrinsics_binary(cameras_extrinsic_file)
         cam_intrinsics = read_intrinsics_binary(cameras_intrinsic_file)
-    except:
+    except Exception:
         cameras_extrinsic_file = os.path.join(path, "sparse/0", "images.txt")
         cameras_intrinsic_file = os.path.join(path, "sparse/0", "cameras.txt")
         cam_extrinsics = read_extrinsics_text(cameras_extrinsic_file)
@@ -161,12 +161,12 @@ def readColmapSceneInfo(path, images, eval, llffhold=8):
         print("Converting point3d.bin to .ply, will happen only the first time you open the scene.")
         try:
             xyz, rgb, _ = read_points3D_binary(bin_path)
-        except:
+        except Exception:
             xyz, rgb, _ = read_points3D_text(txt_path)
         storePly(ply_path, xyz, rgb)
     try:
         pcd = fetchPly(ply_path)
-    except:
+    except Exception:
         pcd = None
 
     scene_info = SceneInfo(point_cloud=pcd,
@@ -244,7 +244,7 @@ def readNerfSyntheticInfo(path, white_background, eval, extension=".png"):
         storePly(ply_path, xyz, SH2RGB(shs) * 255)
     try:
         pcd = fetchPly(ply_path)
-    except:
+    except Exception:
         pcd = None
 
     scene_info = SceneInfo(point_cloud=pcd,

--- a/scene/gaussian_model.py
+++ b/scene/gaussian_model.py
@@ -23,7 +23,7 @@ from utils.general_utils import strip_symmetric, build_scaling_rotation
 
 try:
     from diff_gaussian_rasterization import SparseGaussianAdam
-except:
+except Exception:
     pass
 
 class GaussianModel:


### PR DESCRIPTION
Replace bare `except:` with `except Exception:` in 4 files (7 sites). Bare `except:` catches `BaseException` including `KeyboardInterrupt`/`SystemExit`.

**Files:** `gaussian_renderer/__init__.py`, `metrics.py`, `scene/dataset_readers.py` (4), `scene/gaussian_model.py`